### PR TITLE
Pinned to nightly release in the toolchain file.

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "nightly"
+components = ["rustfmt", "rust-src", "clippy"]
+


### PR DESCRIPTION
I couldn't compile even after installing the nightly toolchain, thus I added [the toolchain file](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file) so that it will default to nightly when there are other toolchains installed.