### PR TITLE
Fix: inherits missing at lto.optimized profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,3 +51,4 @@ dirs-next = "2.0.0"
 [profile.lto-optimized]
 codegen-units = 1
 lto = true
+inherits = "release"


### PR DESCRIPTION
The cargo won't finish compiling with the `--release` flag due to a missing `inherits = "Release"` at the `[profile.lto.optimized]` profile.