### PR TITLE
Fix  startup panic caused by invalid clap argument ID

### DIFF
--- a/bin/main.rs
+++ b/bin/main.rs
@@ -34,7 +34,7 @@ struct Args {
     #[arg(long)]
     cfg_manifest: bool,
     /// Load the default config
-    #[arg(long, conflicts_with_all = ["load", "profile", "init-config"])]
+    #[arg(long, conflicts_with_all = ["load", "profile", "init_config"])]
     no_load: bool,
     #[cfg_attr(
         target_os = "windows",


### PR DESCRIPTION
## Fix `--no-load` startup panic caused by invalid clap argument ID

Fixes https://github.com/AhoyISki/duat/issues/63

**What changed**

- fixed a clap `conflicts_with_all` mismatch by referencing `init_config` instead of `init-config`

**Why**

The CLI panicked at startup because clap was given a conflict target name that did not match the actual argument ID. Clap uses the struct field name (`init_config`) as the internal ID, not the kebab-case flag name (`init-config`), so the debug assertion fired before any UI was launched.

**Result**

- `cargo run` no longer panics

