### PR TITLE
Fix `cargo run` blank terminal caused by `Selections` bincode format …

### DIFF
--- a/crates/duat-core/src/mode/edit/selections.rs
+++ b/crates/duat-core/src/mode/edit/selections.rs
@@ -39,12 +39,49 @@ use crate::{
 /// [`Handle`]: crate::context::Handle
 /// [`edit_`]: crate::context::Handle::edit_all
 /// [`Text`]: crate::text::Text
-#[derive(bincode::Decode, bincode::Encode)]
 pub struct Selections {
     buf: GapBuffer<Selection>,
     main_i: usize,
     shift: Mutex<Shift>,
     version: u64,
+}
+
+impl bincode::Encode for Selections {
+    fn encode<E: bincode::enc::Encoder>(
+        &self,
+        encoder: &mut E,
+    ) -> Result<(), bincode::error::EncodeError> {
+        bincode::Encode::encode(&self.buf, encoder)?;
+        bincode::Encode::encode(&self.main_i, encoder)?;
+        bincode::Encode::encode(&self.shift, encoder)?;
+        Ok(())
+    }
+}
+
+impl<Context> bincode::Decode<Context> for Selections {
+    fn decode<D: bincode::de::Decoder<Context = Context>>(
+        decoder: &mut D,
+    ) -> Result<Self, bincode::error::DecodeError> {
+        Ok(Self {
+            buf: bincode::Decode::decode(decoder)?,
+            main_i: bincode::Decode::decode(decoder)?,
+            shift: bincode::Decode::decode(decoder)?,
+            version: 0,
+        })
+    }
+}
+
+impl<'de, Context> bincode::BorrowDecode<'de, Context> for Selections {
+    fn borrow_decode<D: bincode::de::BorrowDecoder<'de, Context = Context>>(
+        decoder: &mut D,
+    ) -> Result<Self, bincode::error::DecodeError> {
+        Ok(Self {
+            buf: bincode::BorrowDecode::borrow_decode(decoder)?,
+            main_i: bincode::BorrowDecode::borrow_decode(decoder)?,
+            shift: bincode::BorrowDecode::borrow_decode(decoder)?,
+            version: 0,
+        })
+    }
 }
 
 impl Selections {


### PR DESCRIPTION
## Problem

Commit `9b71f4ff` added a `version: u64` field to `Selections`, which derives `bincode::Encode/Decode`. Because bincode serializes fields in declaration order with no schema, this silently changed the IPC wire format of `InitialState`.

The runner (built from new source) encodes `Selections` as `[buf][main_i][shift][version]`, but the already-compiled config binary at `~/.config/duat/target/release/duat` still expects `[buf][main_i][shift]`. Deserialization misaligns, the IPC channel closes, the terminal is left in raw mode, and the process becomes unkillable without an external `kill`.

Closes https://github.com/AhoyISki/duat/issues/62

## Solution

Replaced `#[derive(bincode::Encode, bincode::Decode)]` on `Selections` with manual implementations that serialize only the original three fields (`buf`, `main_i`, `shift`). `version` is initialized to `0` on decode, since it is a runtime-only counter that carries no meaning across the IPC boundary.

## Testing

- `cargo check` passes
- Starting the editor no longer hangs with a previously compiled config binary

## Affected file

- `crates/duat-core/src/mode/edit/selections.rs`