### PR TITLE
refactor: remove Text::selections_mut from public API

### DIFF
--- a/crates/duat-base/src/modes/inc_search.rs
+++ b/crates/duat-base/src/modes/inc_search.rs
@@ -99,7 +99,7 @@ impl<I: IncSearcher> PromptMode for IncSearch<I> {
                 self.widget
                     .area()
                     .set_print_info(pa, orig_print_info.clone());
-                *self.widget.selections_mut(pa) = orig_selections.clone();
+                self.widget.replace_selections(pa, orig_selections.clone());
 
                 let ast = regex_syntax::ast::parse::Parser::new()
                     .parse(&text.to_string_no_last_nl())
@@ -142,7 +142,7 @@ impl<I: IncSearcher> PromptMode for IncSearch<I> {
             self.widget
                 .area()
                 .set_print_info(pa, orig_print_info.clone());
-            *self.widget.selections_mut(pa) = orig_selections.clone();
+            self.widget.replace_selections(pa, orig_selections.clone());
         } else {
             let pat = text.to_string_no_last_nl();
             if let Err(err) = regex_syntax::parse(&pat) {

--- a/crates/duat-base/src/snippets.rs
+++ b/crates/duat-base/src/snippets.rs
@@ -315,7 +315,7 @@ pub(crate) fn jump_snippets(buffer: &Handle, pa: &mut Pass, mut by: i32) -> bool
             .clone()
             .into_iter();
 
-        buffer.selections_mut(pa).remove_extras();
+        buffer.remove_extra_selections(pa);
         buffer.edit_main(pa, |mut s| {
             if let Some(range) = ranges.next() {
                 s.move_to(range);

--- a/crates/duat-base/src/widgets/linenumbers.rs
+++ b/crates/duat-base/src/widgets/linenumbers.rs
@@ -51,7 +51,7 @@ pub fn linenumbers_setup() {
             MouseEventKind::Down(MouseButton::Left) => {
                 let line = line(pa, &buffer);
 
-                buffer.selections_mut(pa).remove_extras();
+                buffer.remove_extra_selections(pa);
                 buffer.edit_main(pa, |mut s| {
                     s.unset_anchor();
                     s.move_to_coords(line, 0)
@@ -60,7 +60,7 @@ pub fn linenumbers_setup() {
             MouseEventKind::Drag(MouseButton::Left) => {
                 let line = line(pa, &buffer);
 
-                buffer.selections_mut(pa).remove_extras();
+                buffer.remove_extra_selections(pa);
                 buffer.edit_main(pa, |mut s| {
                     s.set_anchor_if_needed();
                     s.move_to_coords(line, 0)

--- a/crates/duat-base/src/widgets/logbook.rs
+++ b/crates/duat-base/src/widgets/logbook.rs
@@ -119,7 +119,7 @@ pub fn logbook_setup() {
             {
                 let buffer = context::buffer_from_path(pa, Path::new(location.file())).unwrap();
                 mode::reset_to(pa, &buffer);
-                buffer.selections_mut(pa).remove_extras();
+                buffer.remove_extra_selections(pa);
                 buffer.edit_main(pa, |mut s| {
                     s.move_to_coords(location.line() - 1, location.column() - 1);
                 });

--- a/crates/duat-base/src/widgets/picker.rs
+++ b/crates/duat-base/src/widgets/picker.rs
@@ -195,14 +195,14 @@ impl Picker {
         match pv.modes.remove(pv.current) {
             Some(PreviewMode::BufferMirror(buffer, range)) => {
                 mode::reset_to(pa, &buffer);
-                buffer.selections_mut(pa).remove_extras();
+                buffer.remove_extra_selections(pa);
                 buffer.edit_main(pa, |mut s| s.move_to(range.clone()));
             }
             Some(PreviewMode::BufferPreview(path, mut text, range)) => {
                 if let Some(buffer) = context::buffer_from_path(pa, &path) {
                     buffer.text_mut(pa).replace_range(.., text.to_string());
                     mode::reset_to(pa, &buffer);
-                    buffer.selections_mut(pa).remove_extras();
+                    buffer.remove_extra_selections(pa);
                     buffer.edit_main(pa, |mut s| s.move_to(range.clone()));
                 } else {
                     duat_core::try_or_log_err! {
@@ -213,7 +213,7 @@ impl Picker {
                     let call = if on_new_window { "open" } else { "edit" };
                     if cmd::call_notify(pa, format!("{call} {}", path.to_string_lossy())).is_ok() {
                         let buffer = context::current_buffer(pa);
-                        buffer.selections_mut(pa).remove_extras();
+                        buffer.remove_extra_selections(pa);
                         buffer.edit_main(pa, |mut s| s.move_to(range.clone()));
                     }
                 }

--- a/crates/duat-core/src/buffer/mod.rs
+++ b/crates/duat-core/src/buffer/mod.rs
@@ -52,7 +52,7 @@ pub(crate) fn add_buffer_hooks() {
             };
 
             if let Some(point) = point {
-                event.handle.selections_mut(pa).remove_extras();
+                event.handle.remove_extra_selections(pa);
                 event.handle.edit_main(pa, |mut s| {
                     s.unset_anchor();
                     s.move_to(point)
@@ -70,7 +70,7 @@ pub(crate) fn add_buffer_hooks() {
             };
 
             if let Some(point) = point {
-                event.handle.selections_mut(pa).remove_extras();
+                event.handle.remove_extra_selections(pa);
                 event.handle.edit_main(pa, |mut s| {
                     s.set_anchor_if_needed();
                     s.move_to(point);
@@ -383,9 +383,20 @@ impl Buffer {
         self.text.selections()
     }
 
-    /// A mutable reference to the [`Selections`].
-    pub fn selections_mut(&mut self) -> &mut Selections {
-        self.text.selections_mut()
+    pub fn remove_extra_selections(&mut self) {
+        self.text.remove_extra_selections();
+    }
+
+    pub fn rotate_main_selection(&mut self, amount: i32) {
+        self.text.rotate_main_selection(amount);
+    }
+
+    pub fn set_main_selection(&mut self, n: usize) {
+        self.text.set_main_selection(n);
+    }
+
+    pub fn replace_selections(&mut self, saved: Selections) {
+        self.text.replace_selections(saved);
     }
 
     /// Whether o not the [`Buffer`] exists or not.

--- a/crates/duat-core/src/context/handles.rs
+++ b/crates/duat-core/src/context/handles.rs
@@ -531,13 +531,20 @@ impl<W: Widget + ?Sized> Handle<W> {
         self.text(pa).selections()
     }
 
-    /// A mutable reference to the [`Selections`] of the [`Widget`]'s
-    /// [`Text`].
-    ///
-    /// This is the same as calling
-    /// `handle.write(pa).selections_mut()`.
-    pub fn selections_mut<'p>(&'p self, pa: &'p mut Pass) -> &'p mut Selections {
-        self.text_mut(pa).mv_selections_mut()
+    pub fn remove_extra_selections<'p>(&'p self, pa: &'p mut Pass) {
+        self.text_mut(pa).remove_extra_selections();
+    }
+
+    pub fn rotate_main_selection<'p>(&'p self, pa: &'p mut Pass, amount: i32) {
+        self.text_mut(pa).rotate_main_selection(amount);
+    }
+
+    pub fn set_main_selection<'p>(&'p self, pa: &'p mut Pass, n: usize) {
+        self.text_mut(pa).set_main_selection(n);
+    }
+
+    pub fn replace_selections<'p>(&'p self, pa: &'p mut Pass, saved: Selections) {
+        self.text_mut(pa).replace_selections(saved);
     }
 
     /// Returns a read-write handle (similar to [`RwData`]) for this

--- a/crates/duat-core/src/text/mod.rs
+++ b/crates/duat-core/src/text/mod.rs
@@ -628,9 +628,37 @@ impl Text {
         &self.0.selections
     }
 
+    /// Removes all but the main [`Selection`].
+    pub fn remove_extra_selections(&mut self) {
+        self.0.selections.remove_extras();
+    }
+
+    /// Rotates the main [`Selection`] by `amount`.
+    pub fn rotate_main_selection(&mut self, amount: i32) {
+        self.0.selections.rotate_main(amount);
+    }
+
+    /// Sets the main [`Selection`] to index `n`.
+    pub fn set_main_selection(&mut self, n: usize) {
+        self.0.selections.set_main(n);
+    }
+
+    /// Replaces the current [`Selections`] with `saved`.
+    pub fn replace_selections(&mut self, mut saved: Selections) {
+        if saved.is_empty() {
+            return;
+        }
+        saved.correct_all(&self.0.buf);
+        if !self.ends_with('\n') {
+            self.apply_change(0, Change::str_insert("\n", self.end_point()), true);
+        }
+        self.0.selections = saved;
+        self.0.selections.increment_version();
+    }
+
     /// A mut reference to this `Text`'s [`Selections`] if they
     /// exist.
-    pub fn selections_mut(&mut self) -> &mut Selections {
+    pub(crate) fn selections_mut(&mut self) -> &mut Selections {
         &mut self.0.selections
     }
 
@@ -1009,9 +1037,29 @@ impl<'t> TextMut<'t> {
 
     ////////// Selections functions
 
+    /// Removes all but the main [`Selection`].
+    pub fn remove_extra_selections(&mut self) {
+        self.text.remove_extra_selections();
+    }
+
+    /// Rotates the main [`Selection`] by `amount`.
+    pub fn rotate_main_selection(&mut self, amount: i32) {
+        self.text.rotate_main_selection(amount);
+    }
+
+    /// Sets the main [`Selection`] to index `n`.
+    pub fn set_main_selection(&mut self, n: usize) {
+        self.text.set_main_selection(n);
+    }
+
+    /// Replaces the current [`Selections`] with `saved`.
+    pub fn replace_selections(&mut self, saved: Selections) {
+        self.text.replace_selections(saved);
+    }
+
     /// A mut reference to this `Text`'s [`Selections`] if they
     /// exist.
-    pub fn selections_mut(&mut self) -> &mut Selections {
+    pub(crate) fn selections_mut(&mut self) -> &mut Selections {
         &mut self.text.0.selections
     }
 

--- a/crates/duat-jump-list/src/lib.rs
+++ b/crates/duat-jump-list/src/lib.rs
@@ -89,7 +89,7 @@ impl Jump {
     pub fn apply(&self, pa: &mut Pass, buffer: &Handle) {
         match self {
             Jump::Single(selection) => {
-                buffer.write(pa).selections_mut().remove_extras();
+                buffer.write(pa).remove_extra_selections();
                 buffer.edit_main(pa, |mut s| {
                     let start = s.text().point_at_byte(selection.start);
                     let end = s.text().point_at_byte(selection.end);
@@ -97,7 +97,7 @@ impl Jump {
                 });
             }
             Jump::Multiple(selections, main) => {
-                buffer.write(pa).selections_mut().remove_extras();
+                buffer.write(pa).remove_extra_selections();
 
                 buffer.edit_main(pa, |mut s| {
                     let mut is_first = true;
@@ -112,7 +112,7 @@ impl Jump {
                         is_first = false;
                     }
                 });
-                buffer.write(pa).selections_mut().set_main(*main);
+                buffer.write(pa).set_main_selection(*main);
             }
         }
     }

--- a/crates/duatmode/src/normal.rs
+++ b/crates/duatmode/src/normal.rs
@@ -749,8 +749,8 @@ impl Mode for Normal {
             alt!(';') => widget.edit_all(pa, |mut s| s.swap_ends()),
             event!(';') => widget.edit_all(pa, |mut s| _ = s.unset_anchor()),
             alt!(':') => widget.edit_all(pa, |mut s| _ = s.set_cursor_on_end()),
-            event!(')') => widget.selections_mut(pa).rotate_main(1),
-            event!('(') => widget.selections_mut(pa).rotate_main(-1),
+            event!(')') => widget.rotate_main_selection(pa, 1),
+            event!('(') => widget.rotate_main_selection(pa, -1),
             // TODO: Implement parameter
             alt!(')') => {
                 if widget.selections(pa).len() == 1 {
@@ -1028,7 +1028,7 @@ impl Mode for Normal {
             }
 
             ////////// SelectionMut creation and destruction
-            event!(',') => widget.selections_mut(pa).remove_extras(),
+            event!(',') => widget.remove_extra_selections(pa),
             event!('C') | alt!('C') => {
                 fn cols_eq(lhs: (VPoint, Option<VPoint>), rhs: (VPoint, Option<VPoint>)) -> bool {
                     lhs.0.visual_col() == rhs.0.visual_col()
@@ -1067,9 +1067,7 @@ impl Mode for Normal {
                     s.destroy();
                 });
 
-                widget
-                    .selections_mut(pa)
-                    .set_main(nth + (key_event.modifiers == KeyMod::NONE) as usize);
+                widget.set_main_selection(pa, nth + (key_event.modifiers == KeyMod::NONE) as usize);
             }
 
             ////////// Search keys
@@ -1206,7 +1204,7 @@ impl Mode for Normal {
             event!(':') => mode::set(pa, RunCommands::new()),
             event!('|') => mode::set(pa, PipeSelections::new()),
             event!('g') if param_was_set => {
-                widget.selections_mut(pa).remove_extras();
+                widget.remove_extra_selections(pa);
                 widget.edit_main(pa, |mut s| {
                     s.unset_anchor();
                     s.move_to_coords(param - 1, 0);
@@ -1218,7 +1216,7 @@ impl Mode for Normal {
             }
             event!('g') => self.one_key = Some(OneKey::GoTo(SelType::Normal)),
             event!('G') if param_was_set => {
-                widget.selections_mut(pa).remove_extras();
+                widget.remove_extra_selections(pa);
                 widget.edit_main(pa, |mut s| {
                     s.set_anchor_if_needed();
                     s.move_to_coords(param - 1, 0)


### PR DESCRIPTION
## Summary

- Demotes `Text::selections_mut` and `TextMut::selections_mut` to `pub(crate)`, closing the HIGH PRIORITY known bug in TODO:36
- Adds four narrow safe wrappers on `Text`, `TextMut`, `Handle<W>`, and `Buffer`: `remove_extra_selections`, `rotate_main_selection`, `set_main_selection`, and `replace_selections`
- `replace_selections` corrects incoming selections against the current buffer and ensures the trailing-newline invariant, preventing silent state corruption from raw assignment
- Migrates all 18 external call sites across `duat-base`, `duatmode`, and `duat-jump-list` to the new API

## Why

Callers who held `&mut Selections` directly could assign a cloned `Selections` without bumping the version counter, bypass the lazy-shift `Mutex<Shift>`, or leave `main_i` invalid relative to the buffer size, all silent bugs. The new wrappers enforce these invariants at the call site.

## Test plan

- [x] `cargo check --workspace` , zero errors
- [x] `grep -rn "pub fn selections_mut" crates --include="*.rs"` , zero results
- [x] `grep -rn "\.selections_mut" crates --include="*.rs" | grep -v "crates/duat-core/"` , zero results
