### PR TITLE
fix(duat-core): syntax errors in session.rs

### DIFF
--- a/crates/duat-core/src/session.rs
+++ b/crates/duat-core/src/session.rs
@@ -35,7 +35,7 @@ pub(crate) static BUFFER_OPTS: OnceLock<BufferOpts> = OnceLock::new();
 /// Starts running duat.
 #[doc(hidden)]
 #[inline(never)]
-pub fn start(setup: fn() -> (Ui, BufferOpts)) -> std::io::Result<)> {
+pub fn start(setup: fn() -> (Ui, BufferOpts)) -> std::io::Result<()> {
     static PANIC_INFO: Mutex<Option<String>> = Mutex::new(None);
 
     log::set_logger(Box::leak(Box::new(context::logs()))).unwrap();
@@ -222,16 +222,15 @@ fn main_loop(ui: Ui, is_first_time: bool) -> Vec<Vec<ReloadedBuffer>> {
 
             correct_window_nodes(pa, &mut windows_nodes);
 
-        if printed_at_least_one {
-            ui.print()
+            if printed_at_least_one {
+                ui.print()
+            }
+
+            last_win = cur_win;
+            last_win_len = cur_win_len;
         }
-
-        last_win = cur_win;
-        last_win_len = cur_win_len;
-    }
-  
-
-print_screen(pa, true);
+    };
+    print_screen(pa, true);
 
     loop {
         if let Some(event) = duat_rx.recv(&mut chain_events_instant) {


### PR DESCRIPTION
not sure if the return type of `Result<()>` makes sense here, but at least it compiles!

EDIT: contributing this because re-creating a config from scratch gives me the following:

```
error: unexpected closing delimiter: `)`
  --> crates/duat-core/src/session.rs:38:66
   |
14 | use crate::{
   |            - this opening brace...
...
31 | };
   | - ...matches this closing brace
...
38 | pub fn start(setup: fn() -> (Ui, BufferOpts)) -> std::io::Result<)> {
   |                                                                  ^ unexpected closing delimiter

error: could not compile `duat-core` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
error: failed to compile `duat v0.10.2 (https://github.com/AhoyISki/duat#7e42e992)`, intermediate artifacts can be found at `/tmp/cargo-installk7hppV`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_BUILD_BUILD_DIR` to that path.
```